### PR TITLE
Ruby 2.4.1 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: ruby
 sudo: false # Use Travis containers
 rvm:
+  - 2.4.1
+  - 2.3.4
+  - 2.2.7
   - 2.1
   - 2.1.1
 #  - 2.1.0 - commented out pending resolution of Issue #7
-  - 2.0.0
-  - 2.0.0-p0
-  - 1.9.3
-  - 1.9.3-p484
 script: bundle exec rspec spec

--- a/lib/net/tns/connection.rb
+++ b/lib/net/tns/connection.rb
@@ -127,6 +127,10 @@ module Net
 
       # @param packet [Net::TNS::Packet]
       def send_tns_packet( packet )
+        if @socket.nil? || @socket.closed?
+          Net::TNS.logger.warn( "Can't send packet to a closed or nil socket!" )
+          return
+        end
         # Store this in case we get a Resend
         @tns_last_sent_packet = packet
         Net::TNS.logger.debug( "Sending packet #{packet.class} (#{packet.num_bytes} bytes)" )

--- a/lib/net/tti/crypto.rb
+++ b/lib/net/tti/crypto.rb
@@ -152,7 +152,7 @@ module Net::TTI
 
     # Helper function for encryption.
     def self.openssl_encrypt( cipher, key, iv, data, padding=false )
-      cipher = OpenSSL::Cipher::Cipher.new( cipher )
+      cipher = OpenSSL::Cipher.new( cipher )
       cipher.encrypt
       cipher.key = key
       cipher.iv = iv unless iv.nil?
@@ -163,7 +163,7 @@ module Net::TTI
 
     # Helper function for decryption.
     def self.openssl_decrypt( cipher, key, iv, data, padding=false )
-      cipher = OpenSSL::Cipher::Cipher.new( cipher )
+      cipher = OpenSSL::Cipher.new( cipher )
       cipher.decrypt
       cipher.key = key
       cipher.iv = iv unless iv.nil?

--- a/spec/net/tti/crypto_spec.rb
+++ b/spec/net/tti/crypto_spec.rb
@@ -9,24 +9,24 @@ module Net::TTI
 
       context "when using AES-128-CBC" do
         it "should encrypt and decrypt to the original value" do
-          ciphertext = Crypto.openssl_encrypt( "AES-128-CBC", key, nil, plaintext, true )
-          decrypted_text = Crypto.openssl_decrypt( "AES-128-CBC", key, nil, ciphertext, true )
+          ciphertext = Crypto.openssl_encrypt( "AES-128-CBC", key.slice(0, 16), nil, plaintext, true )
+          decrypted_text = Crypto.openssl_decrypt( "AES-128-CBC", key.slice(0, 16), nil, ciphertext, true )
           expect(decrypted_text).to eql( plaintext )
         end
       end
 
       context "when using AES-192-CBC" do
         it "should encrypt and decrypt to the original value" do
-          ciphertext = Crypto.openssl_encrypt( "AES-192-CBC", key, nil, plaintext, true )
-          decrypted_text = Crypto.openssl_decrypt( "AES-192-CBC", key, nil, ciphertext, true )
+          ciphertext = Crypto.openssl_encrypt( "AES-192-CBC", key.slice(0, 24), nil, plaintext, true )
+          decrypted_text = Crypto.openssl_decrypt( "AES-192-CBC", key.slice(0, 24), nil, ciphertext, true )
           expect(decrypted_text).to eql( plaintext )
         end
       end
 
       context "when using DES-CBC" do
         it "should encrypt and decrypt to the original value" do
-          ciphertext = Crypto.openssl_encrypt( "DES-CBC", key, nil, plaintext, true )
-          decrypted_text = Crypto.openssl_decrypt( "DES-CBC", key, nil, ciphertext, true )
+          ciphertext = Crypto.openssl_encrypt( "DES-CBC", key.slice(0, 8), nil, plaintext, true )
+          decrypted_text = Crypto.openssl_decrypt( "DES-CBC", key.slice(0, 8), nil, ciphertext, true )
           expect(decrypted_text).to eql( plaintext )
         end
       end
@@ -136,7 +136,7 @@ module Net::TTI
             key          = "31b22dc665e423e03a88c112c3a09c81487458df684897d1e9749cfe8d4704f828f642bde4abf5ca".tns_unhexify
             iv           = "8020400408021001".tns_unhexify
 
-            password_enc = Crypto.openssl_encrypt( "DES-EDE3-CBC", key, iv, password_obf, true )
+            password_enc = Crypto.openssl_encrypt( "DES-EDE3-CBC", key.slice(0, 24), iv, password_obf, true )
             expect(password_enc[0,16]).to eql( password_enc_known )
           end
         end


### PR DESCRIPTION
Get rid of warning for deprecated OpenSSL usage.
Other ruby 2.4.1 compat updates
Don't send messages if the socket isn't open.