### PR TITLE
Fix for incorrect parsing of VSNNUM

### DIFF
--- a/lib/net/tns/client.rb
+++ b/lib/net/tns/client.rb
@@ -83,7 +83,7 @@ module Net
         vsnnum_decimal = vsnnum_string.to_i
 
         version_components = []
-        version_components << (( vsnnum_decimal >> 24 ) & 0xF)
+        version_components << (( vsnnum_decimal >> 24 ) & 0xFF)
         version_components << (( vsnnum_decimal >> 20 ) & 0xF)
         version_components << (( vsnnum_decimal >> 16 ) & 0xF)
         version_components << (( vsnnum_decimal >>  8 ) & 0xFF)

--- a/spec/net/tns/client_spec.rb
+++ b/spec/net/tns/client_spec.rb
@@ -1,0 +1,22 @@
+require 'net/tns/client'
+
+module Net
+  module TNS
+    describe Client do
+      let(:vsnnum) { '301989888' }
+
+      describe "::parse_vsnnum" do
+        context "when provided a valid VSNNUM string" do
+          it "should return the correct version" do
+            expect(Client.parse_vsnnum(vsnnum)).to eql?('18.0.0.0.0')
+          end
+        end
+        context "when provided a non-string" do
+          it "should raise an error" do
+            expect { Client.parse_vsnnum(12345678) }.to raise_error(ArgumentError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/net/tns/client_spec.rb
+++ b/spec/net/tns/client_spec.rb
@@ -8,7 +8,7 @@ module Net
       describe "::parse_vsnnum" do
         context "when provided a valid VSNNUM string" do
           it "should return the correct version" do
-            expect(Client.parse_vsnnum(vsnnum)).to eql?('18.0.0.0.0')
+            expect(Client.parse_vsnnum(vsnnum)).to eql('18.0.0.0.0')
           end
         end
         context "when provided a non-string" do


### PR DESCRIPTION
When the existing `Client::parse_vsnnum` method is provided the VSNNUM "301989888", the resulting version will be "2.0.0.0.0" when it should instead be "18.0.0.0.0".